### PR TITLE
Out'ish of the Stone Age

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,35 +72,27 @@ module "your_custom_name_for_your_instance_of_this_module" {
 For an example of labels, see the [bootstrap project module](https://github.com/thesis/terraform-google-bootstrap-project#usage).
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| auto\_repair | Uses Google managed health checks to assess state and do repair. Node is drained/termed/recreated. | string | `""` | no |
-| auto\_upgrade | Keeps nodes up to date with latest stable Kubernetes version.  Uses maintenance window. | string | `""` | no |
-| cluster\_secondary\_ip\_cidr\_range | Secondary CIDR range for cluster pods. Required for private GKE. | string | `""` | no |
-| cluster\_secondary\_range\_name | Secondary IP range name for GKE cluster pods. Required for private GKE. | string | `""` | no |
-| daily\_maintenance\_window\_start\_time | Time window where daily maintenance operations can start. | string | `""` | no |
-| disk\_size\_gb | Size for node disk. | string | `""` | no |
-| disk\_type | Disk type mounted to nodes. pd-hdd, pd-ssd | string | `""` | no |
-| gke\_cluster |  | map | `<map>` | no |
-| gke\_node\_pool |  | map | `<map>` | no |
-| gke\_subnet |  | map | `<map>` | no |
-| image\_type | Base image for nodes. | string | `""` | no |
-| labels | A list of key/value pairs to describe your resource.  Labels are akin to tags. | map | `<map>` | no |
-| machine\_type | Machine type for nodes. | string | `""` | no |
-| master\_ipv4\_cidr\_block | IP range for master.  Must not overlap GKE subnet primary/secondary ranges.  Must be a /28 netmask. | string | `""` | no |
-| network\_policy\_enabled | Whether or not the cluster can configure network policies. | string | `""` | no |
-| node\_count | The number of nodes for the pool.  Nodes per zone. | string | `""` | no |
-| oauth\_scopes | Google APIs the GKE cluster has access to. | list | `<list>` | no |
-| primary\_ip\_cidr\_range | The subnet's primary range. | string | `""` | no |
-| project | The project id of the project you want to create the bucket in. | string | `""` | no |
-| region | The region where resources are generated. | string | `""` | no |
-| services\_secondary\_ip\_cidr\_range | Secondary CIDR range for services.  Required for private GKE. | string | `""` | no |
-| services\_secondary\_range\_name | Secondary IP range name for GKE services. Required for private GKE. | string | `""` | no |
-| subnet | The subnet to build GKE in. Subnet generated in GKE module used. | string | `""` | no |
-| tags | Network tags to apply to VMs.  This impacts routing and firewall rules. | list | `<list>` | no |
-| vpc\_network\_name | Name of the vpc network to associate GKE cluster with. | string | `""` | no |
+|------|-------------|------|---------|:--------:|
+| gke\_cluster | n/a | `map` | `{}` | no |
+| gke\_node\_pool | n/a | `map` | `{}` | no |
+| gke\_subnet | n/a | `map` | `{}` | no |
+| labels | A list of key/value pairs to describe your resource.  Labels are akin to tags. | `map` | `{}` | no |
+| project | The project id of the project you want to create the bucket in. | `string` | `""` | no |
+| region | The region where resources are generated. | `string` | `""` | no |
+| vpc\_network\_name | Name of the vpc network to associate GKE cluster with. | `string` | `""` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| gke\_cluster | n/a | `map` | `{}` | no |
-| gke\_node\_pool | n/a | `map` | `{}` | no |
-| gke\_subnet | n/a | `map` | `{}` | no |
+| gke\_cluster | Configurations related to the cluster master, and general cluster config. | `map` | `{}` | no |
+| gke\_node\_pool | Configurations related to the node pool that will be associated with your cluster. | `map` | `{}` | no |
+| gke\_subnet | Configurations related to setting up the subnet your cluster nodes will go in. | `map` | `{}` | no |
 | labels | A list of key/value pairs to describe your resource.  Labels are akin to tags. | `map` | `{}` | no |
 | project | The project id of the project you want to create the bucket in. | `string` | `""` | no |
 | region | The region where resources are generated. | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ configurable node pool.
 <!-- Compatibility section is optional -->
 ## Compatibility
 
-This module is compatible with Terraform `<= 0.12.0`
-And the Google Cloud Provider `<= 1.19.0`
+| This Module | Terraform | Google Provider |
+|-------------|-----------|-----------------|
+| v0.1.0      | <= 0.12.0 | <= 1.19.0       |
+| v0.2.0      | <= 0.12.0 | <= 2.20.0       |
 
 <!-- Usage section is required -->
 ## Usage
@@ -42,7 +44,6 @@ module "your_custom_name_for_your_instance_of_this_module" {
 
   gke_cluster {
     name                                = "name-of-your-gke-cluster"
-    private_cluster                     = "is-cluster-private"
     master_ipv4_cidr_block              = "ip-range-for-master"
     daily_maintenance_window_start_time = "HH:MM"
     network_policy_enabled              = "can-cluster-configure-network-policies"

--- a/main.tf
+++ b/main.tf
@@ -96,8 +96,6 @@ resource "google_container_node_pool" "a_gke_node_pool" {
     disk_type    = "${lookup(var.gke_node_pool, "disk_type", "")}"
     disk_size_gb = "${lookup(var.gke_node_pool, "disk_size_gb", "")}"
     oauth_scopes = ["${split(",", lookup(var.gke_node_pool, "oauth_scopes", "https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring"))}"]
-
-    tags   = ["${split(",", lookup(var.gke_node_pool, "tags", ""))}"]
     labels = "${var.labels}"
 
     metadata {

--- a/main.tf
+++ b/main.tf
@@ -22,18 +22,18 @@ resource "google_container_cluster" "a_gke_cluster" {
     enable_private_nodes = "${lookup(var.gke_cluster, "enable_private_nodes", true)}"
 
     /* Despite what this looks like, setting enable_private_endpoint to false does not disable the
-         * private endpoint. When false the public endpoint is enabled.  If you want to disable the
-         * public endpoint for a cluster, then set this value to true.
-        */
+             * private endpoint. When false the public endpoint is enabled.  If you want to disable the
+             * public endpoint for a cluster, then set this value to true.
+            */
     enable_private_endpoint = "${lookup(var.gke_cluster, "enable_private_endpoint", false)}"
 
     master_ipv4_cidr_block = "${lookup(var.gke_cluster, "master_ipv4_cidr_block", "")}"
   }
 
   /* Explicitly disable master authorized endpoints by default.  If you need access over a public
-     * interface it should be temporary.  This is typically warranted only during environment
-     * setup when a VPN hasn't been configured yet.
-    */
+       * interface it should be temporary.  This is typically warranted only during environment
+       * setup when a VPN hasn't been configured yet.
+      */
   master_auth {
     username = ""
     password = ""
@@ -96,7 +96,7 @@ resource "google_container_node_pool" "a_gke_node_pool" {
     disk_type    = "${lookup(var.gke_node_pool, "disk_type", "")}"
     disk_size_gb = "${lookup(var.gke_node_pool, "disk_size_gb", "")}"
     oauth_scopes = ["${split(",", lookup(var.gke_node_pool, "oauth_scopes", "https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring"))}"]
-    labels = "${var.labels}"
+    labels       = "${var.labels}"
 
     metadata {
       disable-legacy-endpoints = "true"

--- a/main.tf
+++ b/main.tf
@@ -14,13 +14,24 @@ resource "google_container_cluster" "a_gke_cluster" {
   project = "${var.project}"
   name    = "${lookup(var.gke_cluster, "name", "")}"
   region  = "${var.region}"
-
-  private_cluster        = "${lookup(var.gke_cluster, "private_cluster", "")}"
   network                = "${data.google_compute_network.gke_vpc.self_link}"
   subnetwork             = "${google_compute_subnetwork.a_gke_subnet.self_link}"
-  master_ipv4_cidr_block = "${lookup(var.gke_cluster, "master_ipv4_cidr_block", "")}"
+  
+  private_cluster_config {
+    # Enables a private cluster, creating a private endpoint and nodes with private-only IP's.
+    enable_private_nodes = "${lookup(var.gke_cluster, "enable_private_nodes", true)}"
+    /* Despite what this looks like, setting enable_private_endpoint to false does not disable the
+     * private endpoint. When false the public endpoint is enabled.  If you want to disable the
+     * public endpoint for a cluster, then set this value to true.
+    */ 
+    enable_private_endpoint = "${lookup(var.gke_cluster, "enable_private_endpoint", false)}"
+    master_ipv4_cidr_block = "${lookup(var.gke_cluster, "master_ipv4_cidr_block", "")}"
+  }
 
-  # Empty to disable.
+  /* Explicitly disable master authorized endpoints by default.  If you need access over a public
+   * interface it should be temporary.  This is typically warranted only during environment
+   * setup when a VPN hasn't been configured yet.
+  */ 
   master_auth {
     username = ""
     password = ""

--- a/main.tf
+++ b/main.tf
@@ -11,27 +11,29 @@ data "google_compute_network" "gke_vpc" {
 }
 
 resource "google_container_cluster" "a_gke_cluster" {
-  project = "${var.project}"
-  name    = "${lookup(var.gke_cluster, "name", "")}"
-  region  = "${var.region}"
-  network                = "${data.google_compute_network.gke_vpc.self_link}"
-  subnetwork             = "${google_compute_subnetwork.a_gke_subnet.self_link}"
-  
+  project    = "${var.project}"
+  name       = "${lookup(var.gke_cluster, "name", "")}"
+  region     = "${var.region}"
+  network    = "${data.google_compute_network.gke_vpc.self_link}"
+  subnetwork = "${google_compute_subnetwork.a_gke_subnet.self_link}"
+
   private_cluster_config {
     # Enables a private cluster, creating a private endpoint and nodes with private-only IP's.
     enable_private_nodes = "${lookup(var.gke_cluster, "enable_private_nodes", true)}"
+
     /* Despite what this looks like, setting enable_private_endpoint to false does not disable the
-     * private endpoint. When false the public endpoint is enabled.  If you want to disable the
-     * public endpoint for a cluster, then set this value to true.
-    */ 
+         * private endpoint. When false the public endpoint is enabled.  If you want to disable the
+         * public endpoint for a cluster, then set this value to true.
+        */
     enable_private_endpoint = "${lookup(var.gke_cluster, "enable_private_endpoint", false)}"
+
     master_ipv4_cidr_block = "${lookup(var.gke_cluster, "master_ipv4_cidr_block", "")}"
   }
 
   /* Explicitly disable master authorized endpoints by default.  If you need access over a public
-   * interface it should be temporary.  This is typically warranted only during environment
-   * setup when a VPN hasn't been configured yet.
-  */ 
+     * interface it should be temporary.  This is typically warranted only during environment
+     * setup when a VPN hasn't been configured yet.
+    */
   master_auth {
     username = ""
     password = ""

--- a/variables.tf
+++ b/variables.tf
@@ -24,11 +24,8 @@ variable "labels" {
 }
 
 /* Config maps: Containers to hold logical groupings of GKE
- * configs.  We don't specify key/value pairs in config map defaults.
- * Instead, we define individual variables that represent a config
- * map key/value pair so that we can provide proper descriptions with
- * each configurable option.  See individual variable definitions for
- * descriptions and allowed values.
+ * configs.  These groupings aren't required, but are to try
+ * and help inform how the bits fit together.
 */
 
 /* gke_cluster configs are for the google managed GKE master.
@@ -86,114 +83,4 @@ variable "gke_node_pool" {
   type        = "map"
 
   default = {}
-}
-
-/* Config maps descriptor variables.
- * These are not used directly.  They exist as a reference for each
- * option in one of the aforementioned config maps. In module
- * configuration we use map key/value pairs.
-*/
-
-variable "subnet" {
-  description = "The subnet to build GKE in. Subnet generated in GKE module used."
-  type        = "string"
-  default     = ""
-}
-
-variable "daily_maintenance_window_start_time" {
-  description = "Time window where daily maintenance operations can start."
-  type        = "string"
-  default     = ""
-}
-
-variable "network_policy_enabled" {
-  description = "Whether or not the cluster can configure network policies."
-  type        = "string"
-  default     = ""
-}
-
-## gke_node_pool vars
-variable "node_count" {
-  description = "The number of nodes for the pool.  Nodes per zone."
-  type        = "string"
-  default     = ""
-}
-
-variable "image_type" {
-  description = "Base image for nodes."
-  type        = "string"
-  default     = ""
-}
-
-variable "machine_type" {
-  description = "Machine type for nodes."
-  type        = "string"
-  default     = ""
-}
-
-variable "disk_type" {
-  description = "Disk type mounted to nodes. pd-hdd, pd-ssd"
-  type        = "string"
-  default     = ""
-}
-
-variable "disk_size_gb" {
-  description = "Size for node disk."
-  type        = "string"
-  default     = ""
-}
-
-variable "oauth_scopes" {
-  description = "Google APIs the GKE cluster has access to."
-  type        = "list"
-  default     = []
-}
-
-variable "tags" {
-  description = "Network tags to apply to VMs.  This impacts routing and firewall rules."
-  type        = "list"
-  default     = []
-}
-
-variable "auto_repair" {
-  description = "Uses Google managed health checks to assess state and do repair. Node is drained/termed/recreated."
-  type        = "string"
-  default     = ""
-}
-
-variable "auto_upgrade" {
-  description = "Keeps nodes up to date with latest stable Kubernetes version.  Uses maintenance window."
-  type        = "string"
-  default     = ""
-}
-
-## gke_subnet vars
-variable "primary_ip_cidr_range" {
-  description = "The subnet's primary range."
-  type        = "string"
-  default     = ""
-}
-
-variable "services_secondary_range_name" {
-  description = "Secondary IP range name for GKE services. Required for private GKE."
-  type        = "string"
-  default     = ""
-}
-
-variable "services_secondary_ip_cidr_range" {
-  description = "Secondary CIDR range for services.  Required for private GKE."
-  type        = "string"
-  default     = ""
-}
-
-variable "cluster_secondary_range_name" {
-  description = "Secondary IP range name for GKE cluster pods. Required for private GKE."
-  type        = "string"
-  default     = ""
-}
-
-variable "cluster_secondary_ip_cidr_range" {
-  description = "Secondary CIDR range for cluster pods. Required for private GKE."
-  type        = "string"
-  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "labels" {
 */
 
 variable "gke_cluster" {
-  description = ""
+  description = "Configurations related to the cluster master, and general cluster config."
   type        = "map"
   default     = {}
 }
@@ -60,7 +60,7 @@ variable "gke_cluster" {
 */
 
 variable "gke_subnet" {
-  description = ""
+  description = "Configurations related to setting up the subnet your cluster nodes will go in."
   type        = ""
   default     = {}
 }
@@ -79,7 +79,7 @@ variable "gke_subnet" {
 */
 
 variable "gke_node_pool" {
-  description = ""
+  description = "Configurations related to the node pool that will be associated with your cluster."
   type        = "map"
 
   default = {}

--- a/variables.tf
+++ b/variables.tf
@@ -35,12 +35,13 @@ variable "labels" {
  * List of gke_cluster configs:
  * -----------------
  * name
- * private_cluster
- * master_ipv4_cidr_block
  * subnet
  * daily_maintenance_window_start_time
  * network_policy_enabled
  * logging_service
+ * enable_private_nodes
+ * enable_private_endpoint
+ * master_ipv4_cidr_block
 */
 
 variable "gke_cluster" {
@@ -92,13 +93,6 @@ variable "gke_node_pool" {
  * option in one of the aforementioned config maps. In module
  * configuration we use map key/value pairs.
 */
-
-## gke_cluster{}
-variable "master_ipv4_cidr_block" {
-  description = "IP range for master.  Must not overlap GKE subnet primary/secondary ranges.  Must be a /28 netmask."
-  type        = "string"
-  default     = ""
-}
 
 variable "subnet" {
   description = "The subnet to build GKE in. Subnet generated in GKE module used."


### PR DESCRIPTION
### Intro

On Sept 25th 2020 Google Terraform providers that aren't `2.20.3, 3.12.0` or greater will stop working.  Here's the salient bit from the email.

>After September 25, 2020, all new and existing Instance Template Google Compute Engine resources will have an auto-generated name attribute for all network interfaces. These resources will stop being compatible with Terraform Google Cloud Platform Provider versions below 2.20.3 or 3.12.0.

> To continue using Terraform with Google Cloud Platform, you must upgrade your Provider to version 2.20.3, 3.12.0, or greater. These versions ensure the provider continues to manage Instance Template resources. After September 25, 2020, runs of `terraform plan` and `terraform apply` using a provider version older than these will start failing. As a result, if you configure Instance Templates with Terraform using a Provider version below 2.20.3 or 3.12.0, you will receive the following error message:

So, we need to at least have our modules compatible with the `2.20.3` provider.  This module is one with changes that require some work when jumping provider versions.   Here we do that work, while preserving existing clusters.  This means you should be able to incorporate these changes into an existing environment without Terraform asking to recreate the cluster.

### Incompatibility

Version `0.1.0` of this module breaks in two places when upgrading to the `2.20.x` Google provider:

```
Error: module.gke_cluster.google_container_cluster.a_gke_cluster: : invalid or unknown key: master_ipv4_cidr_block
Error: module.gke_cluster.google_container_cluster.a_gke_cluster: : invalid or unknown key: private_cluster
```
These errors stem from a schema change in the `google_container_cluster` Terraform resources.

### What We Did

- Included the new `private_cluster_config {}` section for the `google_container_cluster` resource.
- Moved `master_ipv4_cidr_block` from top  level `google_container_cluster` config under `private_cluster_config {}` where it's now expected.
- Removed `private_cluster` argument, it's no longer part of the `google_container_cluster` resource definition.
- Included two new arguments for `enable_private_nodes` and `enable_private_endpoint`.  
  - `enable_private_nodes` essentially  replaces the function of the `private_cluster` argument that was removed.  Setting this to `true` enables a private cluster.
   - `enable_private_endpoint` lets  you toggle whether the public endpoint for the cluster is enabled.  Set to `false` to enable the public endpoint, set to `true` to disable the public endpoint.  In either case the private endpoint remains enabled, this is a function setting `enable_private_nodes` to `true.`

### Testing  (demo-dev)
-  Remove `.terraform`.
- Update Google provider to `2.20.3`.
- Remove `null`, `random`, and `template` provider version pegs.  The need for these will go away with the upgrades.
- Run `terraform init --upgrade`
- Remove now dead `private_cluster` config
- Run `terraform plan --target module.gke_cluster` 

We expect the ^ `plan` to produce no changes, which is what we got:

```
sthompson22 ~/Projects/*** (sthompson22/demo-dev/test-new-google-provider) $ terraform plan --target module.gke_cluster

Warning: module.gke_cluster.google_container_cluster.a_gke_cluster: "region": [DEPRECATED] Use location instead



Warning: module.gke_cluster.google_container_node_pool.a_gke_node_pool: "region": [DEPRECATED] use location instead



Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

random_id.project_id: Refreshing state... (ID: J0o)
google_project.project: Refreshing state... (ID: terraform-demo-dev-274a)
google_compute_network.a_vpc: Refreshing state... (ID: dd-vpc-network)
google_project_service.container: Refreshing state... (ID: terraform-demo-dev-274a/container.googleapis.com)
data.google_compute_network.gke_vpc: Refreshing state...
google_compute_subnetwork.a_gke_subnet: Refreshing state... (ID: us-central1/demo-dev-vpc-subnet-gke-us-central1)
google_container_cluster.a_gke_cluster: Refreshing state... (ID: demo-dev)
google_container_node_pool.a_gke_node_pool: Refreshing state... (ID: us-central1/demo-dev/default-node-pool)

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```

### Use

You will need to source version `0.2.0` of this module to get these compatibility updates, e.g.:

```
module "gke_cluster" {
  source  = "git@github.com:thesis/terraform-google-kubernetes-engine?ref=0.2.0"
  ...
}
```


